### PR TITLE
improve: GitHub認証のボタン設置ページ

### DIFF
--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -21,6 +21,13 @@
 
           <%= f.submit t('.login'), class: "btn btn-secondary" %>
         <% end %>
+
+        <%= link_to auth_at_provider_path(provider: :github), class: "btn btn-light" do %>
+          <i class="fab fa-github mr-2"></i>
+            <span class="has-text-weight-medium">Sign in with Github</span>
+          <% end %>
+        </div>
+
         <div class='text-center'>
           <%= link_to t('.to_register_page'), new_user_path %>
           <%= link_to t('.password_forget'), '#' %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -41,12 +41,6 @@
         <div class='text-center'>
           <%= link_to t('.to_login_page'), login_path %>
         </div>
-
-        <%= link_to auth_at_provider_path(provider: :github), class: "btn btn-light" do %>
-          <i class="fab fa-github mr-2"></i>
-            <span class="has-text-weight-medium">Sign in with Github</span>
-          <% end %>
-        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
* GitHub認証のボタン設置ページを、ユーザー登録ページからログインページに移行。