### PR TITLE
add:ログイン無しでshowページ閲覧

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,5 +1,6 @@
 class CommentsController < ApplicationController
   helper_method :prepare_meta_tags
+  skip_before_action :require_login, only: %i[show]
 
   def create
     @comment = current_user.comments.build(comment_params)
@@ -26,9 +27,9 @@ class CommentsController < ApplicationController
   def prepare_meta_tags(comment)
     image_url = "#{request.base_url}/images/ogp.png?text=#{CGI.escape(comment.body)}"
     set_meta_tags og: {
-      site_name: '詐欺師の手帳',
+      site_name: 'あむ編むcommu',
       title: comment.body,
-      description: 'ユーザーによる詐欺被害の投稿です',
+      description: 'ニットを通してコミュニティを編むアプリです。',
       type: 'website',
       url: comment_url,
       image: image_url,

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -2,6 +2,8 @@ class ProfilesController < ApplicationController
   before_action :require_login, only: %i[new create]
   before_action :set_profile, only: %i[edit update destroy]
   before_action :set_search_profiles_form, only: %i[index search]
+  skip_before_action :require_login, only: %i[index]
+  helper_method :prepare_meta_tags
 
   def index
     @profiles = if (tag_name = params[:tag_name])


### PR DESCRIPTION
Closes #77 
* skip_before_action :require_login, only: %i[show]の追加
* ログイン無しでshowページ閲覧を可能にしました。
* prepare_meta_tags(comment)アクションの設定がデフォルトのままだったので、変更しました。