### PR TITLE
add:カードをクリックして裏面にある獲得アイテムを表示する機能

### DIFF
--- a/app/views/boards/_board.html.erb
+++ b/app/views/boards/_board.html.erb
@@ -15,7 +15,7 @@
   </div>
 </div-->
 
-<div id="board-id-<%= board.id %>">
+<!--div id="board-id-<%= board.id %>">
   <div class="card bg-base-100 w-full max-w-sm shadow-xl bg-yellow-50">
       <figure class="w-full object-cover rounded-t-lg">
         <%= image_tag board.board_image.url if board.board_image.present? %>
@@ -30,4 +30,52 @@
       </button>
     </div>
   </div>
+</div-->
+
+<div id="board-id-<%= board.id %>">
+  <!-- swapをラベルとして使う -->
+  <label class="swap swap-flip text-lg w-full">
+    <!-- チェックボックスが状態を制御 -->
+    <input type="checkbox" class="hidden" />
+
+    <!-- 裏面 (swap-on) -->
+    <div class="swap-on card bg-yellow-50 w-full max-w-sm shadow-xl">
+      <div class="card-body">
+        <h2 class="text-lg font-bold text-base sm:text-lg md:text-xl lg:text-2xl"><%= board.user.first_name %> さんの獲得アイテム</h2>
+        <% if board.user.user_items.any? %>
+          <!-- グリッド: アイテムがある場合 -->
+          <div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-2 justify-items-center">
+            <% board.user.user_items.each do |user_item| %>
+              <div class="rounded-lg shadow-xl">
+                <%= image_tag user_item.item.image, class: 'badge-image rounded-lg shadow', size: '150x150' %>
+              </div>
+            <% end %>
+          </div>
+        <% else %>
+          <!-- 中央揃え: アイテムがない場合 -->
+          <div class="flex items-center justify-center h-24">
+            <p class="text-sm text-gray-500">取得アイテムはありません。</p>
+          </div>
+        <% end %>
+      </div>
+    </div>
+
+
+    <!-- 表面 (swap-off) -->
+    <div class="swap-off card bg-yellow-50 w-full max-w-sm shadow-xl">
+      <figure class="w-full object-cover rounded-t-lg">
+        <%= image_tag board.board_image.url if board.board_image.present? %>
+      </figure>
+      <div class="card-body">
+        <h2 class="text-lg font-bold">Dear, <%= board.title %></h2>
+        <p class="text-sm text-gray-500 truncate"><%= board.body %></p>
+        <p class="text-sm text-gray-500"><%= render board.tags %></p>
+      </div>
+      <div class="card-actions justify-end p-4">
+        <button class="btn btn-secondary text-gray-900">
+          <%= link_to "話しかける", board_path(board) %>
+        </button>
+      </div>
+    </div>
+  </label>
 </div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -11,21 +11,21 @@ module.exports = {
     themes: ["pastel"],
     darkTheme: false,
   },
-  theme: {
-    extend: {
-      animation: {
-        "flip-horizontal": "flip-horizontal 0.7s ease-in-out both",
-      },
-      keyframes: {
-        "flip-horizontal": {
-          "0%": {
-            transform: "rotateY(0)",
-          },
-          "100%": {
-            transform: "rotateY(180deg)",
-          },
-        },
-      },
-    },
-  },
+  // theme: {
+  //   extend: {
+  //     animation: {
+  //       "flip-horizontal": "flip-horizontal 0.7s ease-in-out both",
+  //     },
+  //     keyframes: {
+  //       "flip-horizontal": {
+  //         "0%": {
+  //           transform: "rotateY(0)",
+  //         },
+  //         "100%": {
+  //           transform: "rotateY(180deg)",
+  //         },
+  //       },
+  //     },
+  //   },
+  // },
 };


### PR DESCRIPTION
Closes #117

## 概要
<!-- このセクションでは、このPRの目的と概要を簡潔に説明。 -->
- board#indexのcardに、ユーザー自身が獲得したアイテムを表示する機能を追加しました。

## やったこと
<!-- このプルリクで何をしたのか？ -->
- cardに、daisy UIのコンポーネントの一つである、**Swap icons with flip effect**を応用して、cardの裏面を表示できるようにしました。
- その裏面に、ユーザーが獲得したアイテムを表示しました。

## やらないこと
<!-- このプルリクでやらないことは何か？（あれば。無いなら「無し」でOK）（やらない場合は、いつやるのかを明記する。） -->
- 裏面のタイトルが、ウィンドウ自体の縮小で二列目に行ってしまう。
- いかないようにする設定がうまくいかなかったので、今後の課題です。

## できるようになること（ユーザ目線）
<!-- 何ができるようになるのか？（あれば。無いなら「無し」でOK） -->
- ありがとう一覧（または感謝状一覧）に表示されている感謝状一つ一つをクリックすると、カードが裏面になり、感謝状の送り主が獲得したアイテムを閲覧することができる。

## できなくなること（ユーザ目線）
<!-- 何ができなくなるのか？（あれば。無いなら「無し」でOK） -->
- 

## 動作確認
<!-- どのような動作確認を行ったのか？　結果はどうか？ -->
- ローカル環境で動作確認を行い、期待通り動作しました。

## その他
<!-- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載） -->
- 参考資料
  - Swap icons with flip effect
    - https://daisyui.com/components/swap/

## 関連Issue
<!-- このセクションでは、このPRが関連するIssueやタスクをリンクする。以下のように記述。 -->
- 関連Issue: #
