### PR TITLE
add: タイトルを動的に出力する機能の追加

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,6 @@
 module ApplicationHelper
+  def page_title(title = '')
+    base_title = 'AMUCOMMU'
+    title.present? ? "#{title} | #{base_title}" : base_title
+  end
 end

--- a/app/views/boards/edit.html.erb
+++ b/app/views/boards/edit.html.erb
@@ -1,4 +1,5 @@
-<div class="container">
+<% content_for(:title, t('boards.edit.title')) %>
+<div class="container mx-auto">
   <div class="flex min-h-full flex-col justify-center px-6 py-12 lg:px-8">
     <div class="sm:mx-auto sm:w-full sm:max-w-sm">
       <h2 class="mt-10 text-center text-2xl font-bold leading-9 tracking-tight text-gray-900"><%= t('.title') %></h2>

--- a/app/views/boards/index.html.erb
+++ b/app/views/boards/index.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:title, t('boards.index.title')) %>
 <div class="container mx-auto px-4 mt-3">
   <!-- ... -->
   <!-- 検索フォーム -->

--- a/app/views/boards/new.html.erb
+++ b/app/views/boards/new.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:title, t('boards.new.title')) %>
 <div class="container mx-auto px-4">
   <div class="flex min-h-full flex-col justify-center px-6 py-12 lg:px-8">
     <div class="sm:mx-auto sm:w-full sm:max-w-sm">

--- a/app/views/boards/show.html.erb
+++ b/app/views/boards/show.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:title, @board.title) %>
 <div class="container mx-auto w-full min-h-screen grid place-items-center bg-yellow-50">
   <div class="min-h-screen grid place-items-center bg-yellow-50 py-12">
     <div class="sm:mx-auto sm:w-full sm:max-w-sm">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title><%= content_for(:title) || "AMUCOMMU" %></title>
+    <title><%= page_title(yield(:title)) %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <%= csrf_meta_tags %>

--- a/app/views/pictures/index.html.erb
+++ b/app/views/pictures/index.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:title, t('pictures.index.title')) %>
 <%# エラーメッセージの表示 %>
 <% if @error.present? %>
   <p class="alert alert-danger"><%= @error %></p>

--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:title, t('.title')) %>
 <div class="container mx-auto px-4">
   <div class="flex min-h-full flex-col justify-center px-6 py-12 lg:px-8">
     <div class="sm:mx-auto sm:w-full sm:max-w-sm">

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:title, t('.title')) %>
 <div class="container mx-auto px-4">
   <div class="flex min-h-full flex-col justify-center px-6 py-12 lg:px-8">
     <div class="sm:mx-auto sm:w-full sm:max-w-sm">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:title, t('users.show.title')) %>
 <div class="container mx-auto min-h-screen h-screen px-4">
   <div class="text-center mt-10">
     <h1 class="text-2xl font-bold leading-9 tracking-tight text-gray-900 mb-10">

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -36,20 +36,24 @@ ja:
     create:
       success: ユーザー登録が完了しました
       failure: ユーザー登録に失敗しました
+    show:
+      title: マイページ
   header:
     login: ログイン
     logout: ログアウト
     mypage: マイページ
-    board_index: ありがとう一覧
+    board_index: 感謝状一覧
     create_board: 感謝状作成
     show_item: アイテム一覧
   boards:
-    new: 
+    new:
       title: 感謝状作成
-    show: 
+    show:
       title: 感謝状詳細
-    index: 
+    index:
       title: 感謝状一覧
-    edit: 
+    edit:
       title: 感謝状編集
-    
+  pictures:
+    index:
+      title: 画像生成ページ


### PR DESCRIPTION
Closes #59 

## 概要
<!-- このセクションでは、このPRの目的と概要を簡潔に説明。 -->
- タイトルを動的に出力する機能の追加を追加しました。

## やったこと
<!-- このプルリクで何をしたのか？ -->
- ApplicationHelperモジュール内にタイトルを動的に出力するメソッドを定義しました。
- ベースタイトルをアプリケーション全体に適応するために、```<title><%= page_title(yield(:title)) %></title>```を追加しました。
- 各ページのhtmlファイルに```content_for```メソッドを使い、各ページのタイトルを動的に出力する

## やらないこと
<!-- このプルリクでやらないことは何か？（あれば。無いなら「無し」でOK）（やらない場合は、いつやるのかを明記する。） -->
- 無し

## できるようになること（ユーザ目線）
<!-- 何ができるようになるのか？（あれば。無いなら「無し」でOK） -->
- ブラウザのタブから、自身が今どこのページにいるのかが確認できるようになりました。

## できなくなること（ユーザ目線）
<!-- 何ができなくなるのか？（あれば。無いなら「無し」でOK） -->
- 無し

## 動作確認
<!-- どのような動作確認を行ったのか？　結果はどうか？ -->
- ローカル環境で適切に動いていることを確認できました。

## その他
<!-- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載） -->
- 無し

## 関連Issue
<!-- このセクションでは、このPRが関連するIssueやタスクをリンクする。以下のように記述。 -->
- 関連Issue: #
