### PR TITLE
add: アイテム一覧ページの作成

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,0 +1,15 @@
+class ItemsController < ApplicationController
+  skip_before_action :require_login, only: %i[index]
+  def index
+    if params[:user_id]
+      @user = User.find_by(id: params[:user_id])
+      if @user.nil?
+        redirect_to boards_path, alert: "ユーザーが見つかりません。" and return
+      end
+    else
+      @user = current_user
+    end
+      # ユーザーに紐付いた user_items を取得
+      @user_items = @user.user_items.includes(:item) if @user
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,5 @@
 class UsersController < ApplicationController
-  skip_before_action :require_login, only: %i[new create show]
+  skip_before_action :require_login, only: %i[new create]
 
   def new
     @user = User.new
@@ -13,12 +13,6 @@ class UsersController < ApplicationController
       flash.now[:danger] = t("users.create.failure")
       render :new, status: :unprocessable_entity
     end
-  end
-
-  def show
-    @user = User.find(params[:id])
-    # ユーザーに紐付いた user_items を取得
-    @user_items = @user.user_items.includes(:item)
   end
 
   private

--- a/app/decorators/item_decorator.rb
+++ b/app/decorators/item_decorator.rb
@@ -1,0 +1,13 @@
+class ItemDecorator < Draper::Decorator
+  delegate_all
+
+  # Define presentation-specific methods here. Helpers are accessed through
+  # `helpers` (aka `h`). You can override attributes, for example:
+  #
+  #   def created_at
+  #     helpers.content_tag :span, class: 'time' do
+  #       object.created_at.strftime("%a %m/%d/%y")
+  #     end
+  #   end
+
+end

--- a/app/views/boards/_board.html.erb
+++ b/app/views/boards/_board.html.erb
@@ -7,7 +7,12 @@
     <!-- 裏面 (swap-on) -->
     <div class="swap-on card bg-yellow-50 w-full h-full max-w-xs shadow-xl flex flex-col">
       <div class="card-body overflow-y-auto">
-        <h2 class="text-lg font-bold text-base sm:text-lg md:text-xl lg:text-2xl border-pink-200 border-b-2"><%= board.user.name %> さんの獲得アイテム</h2>
+        <button class="btn btn-ghost"><%= link_to items_path(user_id: board.user.id), class: "block" do %>
+          <h2 class="text-lg font-bold text-base sm:text-lg md:text-xl lg:text-2xl border-pink-200 border-b-2">
+            <%= board.user.name %> さんの獲得アイテム
+          </h2>
+        <% end %></button>
+
         <% if board.user.user_items.any? %>
           <!-- グリッド: アイテムがある場合 -->
           <div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-2 justify-items-center">

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -1,13 +1,8 @@
-<% content_for(:title, t('users.show.title')) %>
+<% content_for(:title, t('items.index.title')) %>
 <div class="container mx-auto min-h-screen h-screen px-4">
   <div class="text-center mt-10">
     <h1 class="text-2xl font-bold leading-9 tracking-tight text-gray-900 mb-10">
-      <%= @user.name %> マイページ
-    </h1>
-  </div>
-  <div class="text-center mt-10">
-    <h1 class="text-2xl font-bold leading-9 tracking-tight text-gray-900 mb-10">
-      <%= @user.name %> アイテム一覧
+      <%= @user.name %> のアイテム一覧
     </h1>
   </div>
   <div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-2 justify-items-center">

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -18,15 +18,14 @@
         <ul
           tabindex="0"
           class="menu menu-sm dropdown-content bg-base-100 rounded-box z-[1] mt-3 w-52 p-2">
-          <li><a><%= current_user.name %></a></li>
           <li>
             <a>
-              <%= link_to t('header.mypage'), user_path(current_user), class: 'dropdown-item' %>
+              <%= link_to t('header.create_board'), new_board_path, class: 'dropdown-item' %>
             </a>
           </li>
           <li>
             <a>
-              <%= link_to t('header.create_board'), new_board_path, class: 'dropdown-item' %>
+              <%= link_to t('header.itempage'), items_path, class: 'dropdown-item' %>
             </a>
           </li>
           <li><a><%= link_to t('header.logout'), logout_path, class: 'dropdown-item', data: { turbo_method: :delete } %></a></li>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -41,7 +41,7 @@ ja:
   header:
     login: ログイン
     logout: ログアウト
-    mypage: マイページ
+    itempage: アイテム一覧
     board_index: 感謝状一覧
     create_board: 感謝状作成
     show_item: アイテム一覧
@@ -57,6 +57,9 @@ ja:
   pictures:
     index:
       title: 画像生成ページ
+  items:
+    index:
+        title: アイテム一覧ページ
   # ページネーション
   views:
     pagination:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,7 @@ Rails.application.routes.draw do
   end
   get "board_sessions/save", to: "board_sessions#save"
   get "board_sessions/clear", to: "board_sessions#clear"
+  resources :items, only: %i[index]
   #get "images/ogp.png", to: "images#ogp", as: "images_ogp"
 
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html


### PR DESCRIPTION
Closes #158 

## 概要
<!-- このセクションでは、このPRの目的と概要を簡潔に説明。 -->
- ユーザーごとのアイテム一覧を表示する。
  - URL例: ```/items?user_id=1```（ユーザー1のアイテム一覧）または```/items```（現在のログインユーザーのアイテム一覧）。
  - 感謝状一覧の投稿の裏面に表示される獲得アイテムのユーザーの名前をクリックすると、ユーザーごとのアイテム一覧ページに飛ぶ。
[![Image from Gyazo](https://i.gyazo.com/8dc3fd6a08e25e059a74f4ce32fbc37e.png)](https://gyazo.com/8dc3fd6a08e25e059a74f4ce32fbc37e)

  - ヘッダーから自分のアイテム一覧に飛ぶ。
[![Image from Gyazo](https://i.gyazo.com/a4ef9db43130f739dc3c30a656a145cb.png)](https://gyazo.com/a4ef9db43130f739dc3c30a656a145cb)

## やったこと
<!-- このプルリクで何をしたのか？ -->
- アイテムコントローラーを作成
- indexアクションで表示
- ページ名をアイテム一覧ページに修正。
- 感謝状一覧の投稿の裏面に表示される獲得アイテムのユーザーの名前を、link_toでそのユーザーのアイテム一覧ページに飛ぶように実装しました。
  - リンクの存在が分かりにくかったので、daisyUIでボタンのゴーストの仕様を使い、マウスを持ってくるとクリックしても良さそうなことがわかるようにしました。

## やらないこと
<!-- このプルリクでやらないことは何か？（あれば。無いなら「無し」でOK）（やらない場合は、いつやるのかを明記する。） -->
- 無し

## できるようになること（ユーザ目線）
<!-- 何ができるようになるのか？（あれば。無いなら「無し」でOK） -->
- ユーザーごとのアイテム一覧を閲覧できるようになりました。
- ヘッダーから自分のアイテム一覧ページにアクセスできること。
- 感謝状一覧の投稿の裏面に表示される獲得アイテムのユーザーの名前をクリックすると、そのユーザーのアイテム一覧ページに飛んで閲覧できること。

## できなくなること（ユーザ目線）
<!-- 何ができなくなるのか？（あれば。無いなら「無し」でOK） -->
- 無し

## 動作確認
<!-- どのような動作確認を行ったのか？　結果はどうか？ -->
- ローカル環境で正常な動作を確認済みです。

## その他
<!-- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載） -->
- 無し

## 関連Issue
<!-- このセクションでは、このPRが関連するIssueやタスクをリンクする。以下のように記述。 -->
- 関連Issue: #27
- 関連Issue: #28 
- 関連Issue: #115 
- 関連Issue: #117 
- 関連Issue: #129 
