### PR TITLE
improve: Xシェア時の大元の画像の修正

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -22,12 +22,14 @@ class ApplicationController < ActionController::Base
         description: :description,
         type: "website",
         url: :current_url,
-        image: './app/assets/images/ogp_image.png'
+        # アセットパイプラインを利用してURLを生成する必要があり、asset_url または asset_path を使用して絶対URLを作成。
+        image: ActionController::Base.helpers.asset_url("ogp_image.png")
+
       },
       twitter: {
         card: "summary_large_image",
         site: "@aiaipanick", # 任意でTwitterアカウントを指定
-        image: './app/assets/images/ogp_image.png'
+        image: ActionController::Base.helpers.asset_url("ogp_image.png")
       }
     }
 


### PR DESCRIPTION
Closes #177 

## 概要
<!-- このセクションでは、このPRの目的と概要を簡潔に説明。 -->
- Xシェア時の大元の画像の修正を行いました。

## やったこと
<!-- このプルリクで何をしたのか？ -->
- アセットパイプラインを利用してURLを生成する必要があり、```'./app/assets/images/ogp_image.png'```部分を、asset_url または asset_path を使用して絶対URLを作成。

## やらないこと
<!-- このプルリクでやらないことは何か？（あれば。無いなら「無し」でOK）（やらない場合は、いつやるのかを明記する。） -->
- 無し

## できるようになること（ユーザ目線）
<!-- 何ができるようになるのか？（あれば。無いなら「無し」でOK） -->
- Xシェア時に、デフォルト画像の投稿もできるようになりました。

## できなくなること（ユーザ目線）
<!-- 何ができなくなるのか？（あれば。無いなら「無し」でOK） -->
- 無し

## 動作確認
<!-- どのような動作確認を行ったのか？　結果はどうか？ -->
-  「Localhost Open Graph Debugger」を使用し、ローカル環境での正常な動作を確認しました。

## その他
<!-- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載） -->
- 無し

## 関連Issue
<!-- このセクションでは、このPRが関連するIssueやタスクをリンクする。以下のように記述。 -->
- 関連Issue: #176 
- 関連Issue: #175 
- 関連Issue: #172
- 関連Issue: #164 
- 関連Issue: #79
- 関連Issue: #77 
