### PR TITLE
improve: Boardになってしまっているところを日本語に修正

### DIFF
--- a/app/controllers/boards_controller.rb
+++ b/app/controllers/boards_controller.rb
@@ -221,8 +221,8 @@ class BoardsController < ApplicationController
 
   def update
     @board.assign_attributes(board_params)
-    if @board.save_with_tags(tag_names: params.dig(:board, :tag_names).split(',').uniq)
-      redirect_to board_path(@board), success: t('defaults.flash_message.updated', item: Board.model_name.human)
+    if @board.save_with_tags(tag_names: params.dig(:board, :tag_names).split('、').uniq)
+      redirect_to board_path(@board), notice: t('defaults.flash_message.updated', item: Board.model_name.human)
     else
       flash.now[:alert] = t('defaults.flash_message.not_updated', item: Board.model_name.human)
       render :edit, status: :unprocessable_entity
@@ -232,7 +232,7 @@ class BoardsController < ApplicationController
   def destroy
     board = current_user.boards.find(params[:id])
     board.destroy!
-    redirect_to boards_path, success: t('defaults.flash_message.deleted', item: Board.model_name.human), status: :see_other
+    redirect_to boards_path, notice: t('defaults.flash_message.deleted', item: Board.model_name.human), status: :see_other
   end
 
   def search

--- a/app/controllers/pictures_controller.rb
+++ b/app/controllers/pictures_controller.rb
@@ -89,10 +89,10 @@ class PicturesController < ApplicationController
         # 投稿数を計算
         check_for_reward(current_user)
 
-        flash[:notice] = "Boardが作成されました！"
+        flash[:notice] = "感謝状が作成されました！"
         redirect_to board_path(board)
       else
-        flash[:alert] = "Boardの保存に失敗しました。再度お試しください。"
+        flash[:alert] = "感謝状の保存に失敗しました。再度お試しください。"
         redirect_to pictures_path
       end
     else

--- a/app/views/pictures/index.html.erb
+++ b/app/views/pictures/index.html.erb
@@ -51,7 +51,7 @@
             <%= hidden_field_tag :body, @body %>
             <%= hidden_field_tag :tag_names, @tag %>
 
-            <%= submit_tag "選択してBoardを作成", class: "btn btn-success" %>
+            <%= submit_tag "選択して感謝状を作成", class: "btn btn-success" %>
           <% end %>
         <% end %>
       </div>


### PR DESCRIPTION
Closes #169 

## 概要
<!-- このセクションでは、このPRの目的と概要を簡潔に説明。 -->
-  画像生成画面の画像を選択後に押すボタンがBoardになってしまっているところを日本語に修正しました。
- それに伴い、フラッシュメッセージの表示も修正しました。

## やったこと
<!-- このプルリクで何をしたのか？ -->
-  画像生成画面の画像を選択後に押すボタンがBoardになってしまっているところを日本語に修正しました。
- それに伴い、フラッシュメッセージの表示も修正しました。

## やらないこと
<!-- このプルリクでやらないことは何か？（あれば。無いなら「無し」でOK）（やらない場合は、いつやるのかを明記する。） -->
- 無し

## できるようになること（ユーザ目線）
<!-- 何ができるようになるのか？（あれば。無いなら「無し」でOK） -->
- 無し

## できなくなること（ユーザ目線）
<!-- 何ができなくなるのか？（あれば。無いなら「無し」でOK） -->
- 無し

## 動作確認
<!-- どのような動作確認を行ったのか？　結果はどうか？ -->
- ローカル環境で確認済み

## その他
<!-- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載） -->
- 無し

## 関連Issue
<!-- このセクションでは、このPRが関連するIssueやタスクをリンクする。以下のように記述。 -->
- 関連Issue:
