### PR TITLE
improve: カードの修正

### DIFF
--- a/app/controllers/pictures_controller.rb
+++ b/app/controllers/pictures_controller.rb
@@ -132,6 +132,8 @@ class PicturesController < ApplicationController
         # ランダムにアイテムを選択
         item_id = Item.pluck(:id).sample # 登録されているアイテムのIDからランダムに取得
         UserItem.create!(user_id: current_user.id, item_id: item_id)
+        flash[:notice] = "アイテムを獲得しました！アイテム一覧を確認しましょう！"
+        redirect_to items_path
       end
     end
   end

--- a/app/views/boards/_board.html.erb
+++ b/app/views/boards/_board.html.erb
@@ -7,10 +7,19 @@
     <!-- 裏面 (swap-on) -->
     <div class="swap-on card bg-yellow-50 w-full h-full max-w-xs shadow-xl flex flex-col">
       <div class="card-body overflow-y-auto">
-        <h2 class="text-lg font-bold text-base sm:text-lg md:text-xl lg:text-2xl border-pink-200 border-b-2"><%= board.user.name %> さんの獲得アイテム</h2>
+        <button class="btn btn-ghost"><%= link_to items_path(user_id: board.user.id), class: "block" do %>
+          <div class="flex">
+            <div class="w-10 rounded-full">
+              <%= image_tag board.user.avatar_url, class: "w-10 rounded-full" %>
+            </div>
+            <h2 class="text-lg font-bold text-base sm:text-lg md:text-xl lg:text-2xl border-pink-200 border-b-2 mb-4">
+              <%= board.user.name %> さんのアイテム
+            </h2>
+          </div>
+        <% end %></button>
         <% if board.user.user_items.any? %>
           <!-- グリッド: アイテムがある場合 -->
-          <div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-2 justify-items-center mt-2">
+          <div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-2 justify-items-center mt-4">
             <% board.user.items.each do |item| %>
               <div class="rounded-lg shadow-xl">
                 <%= image_tag item.image, class: 'badge-image rounded-lg shadow', size: '150x150' %>
@@ -28,7 +37,7 @@
 
 
     <!-- 表面 (swap-off) -->
-    <div class="swap-off card bg-yellow-50 w-full h-full max-w-xs shadow-xl overflow-hidden flex flex-col">
+    <div class="swap-off card bg-yellow-50 w-full h-full max-w-xs shadow-xl overflow-hidden flex flex-col hover:shadow-yellow-200">
       <figure class="w-full rounded-t-lg object-contain">
         <%= image_tag board.board_image.url , class: "rounded-xl object-cover" if board.board_image.present? %>
       </figure>

--- a/app/views/boards/_form.html.erb
+++ b/app/views/boards/_form.html.erb
@@ -1,5 +1,8 @@
 <div class="flex justify-center min-h-screen bg-yellow-50">
   <div class="w-full max-w-lg rounded-lg">
+    <div class="text-gray-500 bg-red-100/50 text-sm mt-6 p-8 rounded-full">
+      <p> 相手の方がもらって嬉しい画像を心を込めて生成しましょう。</p>
+    </div>
       <%= form_with model: @board, class: "new_board" do |f| %>
         <%= render 'shared/error_messages', object: f.object %>
         <div>
@@ -26,9 +29,6 @@
 
         <%= f.submit nil, class: "btn btn-secondary" %>
       <% end %>
-      <div class="text-gray-500 bg-red-100/50 text-sm mt-6 p-8 rounded-full">
-          <p> 相手の方がもらって嬉しい画像を心を込めて生成しましょう。</p>
-        </div>
     </div>
   </div>
 </div>

--- a/app/views/boards/index.html.erb
+++ b/app/views/boards/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:title, t('boards.index.title')) %>
-<div class="container mx-auto min-h-screen h-screen px-4 mt-3">
+<div class="container mx-auto px-4">
   <!-- ... -->
   <!-- 検索フォーム -->
   <%= render 'shared/search_board_form', search_form: @search_form %>
@@ -19,3 +19,4 @@
   </div>
   <%= paginate @boards %>
 </div>
+

--- a/app/views/boards/search.html.erb
+++ b/app/views/boards/search.html.erb
@@ -3,7 +3,7 @@
   <!-- 検索フォーム -->
     <%= render 'shared/search_board_form', search_form: @search_form %>
     <!-- 掲示板一覧 -->
-    <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+    <div class="flex flex-wrap justify-center gap-6">
       <%= render @boards %>
     </div>
 </div>


### PR DESCRIPTION
Closes #170 
- カードの修正

## 概要
<!-- このセクションでは、このPRの目的と概要を簡潔に説明。 -->

## やったこと
<!-- このプルリクで何をしたのか？ -->
- カードにマウスを持ってきたら、ホバーか、光るかして、ユーザーにクリックさせてみたくなるような工夫をする。
- カード裏に、ユーザーのアイコンを表示させる。
- 「話しかける」ボタンを「詳細」ボタンにする。
- 感謝状一覧ページのカードの表示順を、投稿が新しい順にする。
- card裏のユーザーのアイテム一覧へ飛ぶボタンが無くなっていたので、実装し直しました。
- アイテムを獲得したら、フラッシュメッセージが表示されるようになりました。


## やらないこと
<!-- このプルリクでやらないことは何か？（あれば。無いなら「無し」でOK）（やらない場合は、いつやるのかを明記する。） -->
- 無し

## できるようになること（ユーザ目線）
<!-- 何ができるようになるのか？（あれば。無いなら「無し」でOK） -->
- カードをクリックして裏側を確認しやすくなりました。
- カード裏で、その投稿者のアイコンを確認できるようになりました。

## できなくなること（ユーザ目線）
<!-- 何ができなくなるのか？（あれば。無いなら「無し」でOK） -->
- 無し

## 動作確認
<!-- どのような動作確認を行ったのか？　結果はどうか？ -->
- ローカル環境で確認済み。
- フラッシュメッセージの確認はできてません。

## その他
<!-- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載） -->
- 無し

## 関連Issue
<!-- このセクションでは、このPRが関連するIssueやタスクをリンクする。以下のように記述。 -->
- 関連Issue: #
