### PR TITLE
add: boardのシステムスペックの追加

### DIFF
--- a/app/controllers/boards_controller.rb
+++ b/app/controllers/boards_controller.rb
@@ -1,5 +1,5 @@
 class BoardsController < ApplicationController
-  before_action :require_login, only: %i[new create]
+  before_action :require_login, only: %i[new create edit update]
   before_action :set_board, only: %i[edit update destroy]
   before_action :set_search_boards_form, only: %i[index search]
   skip_before_action :require_login, only: %i[index show]

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -72,6 +72,7 @@ RSpec.configure do |config|
     Capybara.server_port = 4444
     Capybara.app_host = "http://#{Capybara.server_host}:#{Capybara.server_port}"
     Capybara.ignore_hidden_elements = false
+    Capybara.default_max_wait_time = 5
   end
 
   # Filter lines from Rails gems in backtraces.
@@ -81,11 +82,4 @@ RSpec.configure do |config|
   config.include FactoryBot::Syntax::Methods
 
   # システムスペック実行前にテストを動かすブラウザを設定
-  config.before(:each, type: :system) do
-    driven_by :remote_chrome
-    Capybara.server_host = IPSocket.getaddress(Socket.gethostname)
-    Capybara.server_port = 4444
-    Capybara.app_host = "http://#{Capybara.server_host}:#{Capybara.server_port}"
-    Capybara.ignore_hidden_elements = false
-  end
 end

--- a/spec/system/boards_spec.rb
+++ b/spec/system/boards_spec.rb
@@ -1,19 +1,108 @@
 require 'rails_helper'
 
 RSpec.describe "Boards", type: :system do
-  before do
-    driven_by(:rack_test)
-  end
+  include LoginMacros
+  let(:user) { create(:user) }
+  let(:board) { create(:board, user: user) } # BoardにUserを紐づける
   describe "ログイン前" do
-    it "感謝状の新規登録ページにアクセスするとアクセし失敗する" do
-
+    context "感謝状の新規作成ページにアクセスする" do
+      it "失敗する" do
+        visit new_board_path
+        expect(page).to have_content "ログインしてください"
+        expect(current_path).to eq(login_path)
+      end
     end
-    it "感謝状の編集ページにアクセスするとアクセし失敗する" do
 
+    context "感謝状の編集ページにアクセスする" do
+      it "失敗する" do
+        visit edit_board_path(board) # ダミーBoardのIDを渡してアクセス
+        expect(page).to have_content "ログインしてください"
+        expect(current_path).to eq(login_path)
+      end
     end
+
     it "感謝状の一覧ページにアクセスすると感謝状一覧が表示される" do
+      board = create(:board) # 先にBoardを作成
+      visit boards_path # 一覧ページにアクセス
+      expect(page).to have_content board.title
+      expect(page).to have_content board.body
+      expect(current_path).to eq boards_path
+    end
+  end
 
+  describe "ログイン後" do
+    before do
+      Capybara.reset_sessions! # セッションのリセット
+      login_as(user)
+    end
+    context "感謝状の新規作成ページにアクセスする" do
+      it "成功する" do
+        click_link "感謝状作成"
+        expect(page).to have_field "感謝を伝えたい人の名前"
+        expect(page).to have_field "感謝メッセージ"
+        expect(page).to have_field "相手のイメージキーワード"
+        expect(page).to have_button "登録"
+        expect(current_path).to eq(new_board_path)
+      end
     end
 
+    context "感謝状の編集ページにアクセスする" do
+      it "成功する" do
+        visit edit_board_path(board) # ダミーBoardのIDを渡してアクセス
+        expect(page).to have_field "感謝を伝えたい人の名前"
+        expect(page).to have_field "感謝メッセージ"
+        expect(page).to have_field "相手のイメージキーワード"
+        expect(page).to have_button "更新"
+        expect(current_path).to eq(edit_board_path(board))
+      end
+
+      it "フォームの入力値が正常で、タスクの編集が成功する" do
+        visit edit_board_path(board) # ダミーBoardのIDを渡してアクセス
+        fill_in "感謝を伝えたい人の名前", with: "Update_name"
+        fill_in "感謝メッセージ", with: "Update_body"
+        fill_in "相手のイメージキーワード", with: "Update_tag"
+        click_button "更新"
+        expect(page).to have_content "感謝状を更新しました"
+        expect(current_path).to eq(board_path(board))
+      end
+
+      it "「感謝を伝えたい人の名前」が未入力で、タスクの編集が失敗する" do
+        visit edit_board_path(board) # ダミーBoardのIDを渡してアクセス
+        fill_in "感謝を伝えたい人の名前", with: " "
+        fill_in "感謝メッセージ", with: "Update_body"
+        fill_in "相手のイメージキーワード", with: "Update_tag"
+        click_button "更新"
+        expect(page).to have_content "感謝状を更新出来ませんでした"
+        expect(current_path).to eq(edit_board_path(board))
+      end
+
+      it "「感謝メッセージ」が未入力で、タスクの編集が失敗する" do
+        visit edit_board_path(board) # ダミーBoardのIDを渡してアクセス
+        fill_in "感謝を伝えたい人の名前", with: "Update_name"
+        fill_in "感謝メッセージ", with: " "
+        fill_in "相手のイメージキーワード", with: "Update_tag"
+        click_button "更新"
+        expect(page).to have_content "感謝状を更新出来ませんでした"
+        expect(current_path).to eq(edit_board_path(board))
+      end
+
+      it "「感謝メッセージ」が未入力で、タスクの編集が失敗する" do
+        visit edit_board_path(board) # ダミーBoardのIDを渡してアクセス
+        fill_in "感謝を伝えたい人の名前", with: "Update_name"
+        fill_in "感謝メッセージ", with: "Update_body"
+        fill_in "相手のイメージキーワード", with: " "
+        click_button "更新"
+        expect(page).to have_content "感謝状を更新出来ませんでした"
+        expect(current_path).to eq(edit_board_path(board))
+      end
+    end
+
+    it "感謝状の一覧ページにアクセスすると感謝状一覧が表示される" do
+      board = create(:board) # 先にBoardを作成
+      visit boards_path # 一覧ページにアクセス
+      expect(page).to have_content board.title
+      expect(page).to have_content board.body
+      expect(current_path).to eq boards_path
+    end
   end
 end


### PR DESCRIPTION
Closes #220 
Closes #244

## 概要
<!-- このセクションでは、このPRの目的と概要を簡潔に説明。 -->
- boardのシステムスペックの追加
- 低でも30%以上はカバー出来ている状態にする
[![Image from Gyazo](https://i.gyazo.com/c29fbded5ab6b31ac47a4bbc66ec7ef2.png)](https://gyazo.com/c29fbded5ab6b31ac47a4bbc66ec7ef2)


## やったこと
<!-- このプルリクで何をしたのか？ -->
- `spec/system/boards_spec.rb`の作成
- `spec/rails_helper.rb`に`Capybara.default_max_wait_time = 5`を加え、# タイムアウトの設定を増やしました（デフォルトは2秒）

## やらないこと
<!-- このプルリクでやらないことは何か？（あれば。無いなら「無し」でOK）（やらない場合は、いつやるのかを明記する。） -->
- 無し

## できるようになること（ユーザ目線）
<!-- 何ができるようになるのか？（あれば。無いなら「無し」でOK） -->
- 無し

## できなくなること（ユーザ目線）
<!-- 何ができなくなるのか？（あれば。無いなら「無し」でOK） -->
- 無し

## 動作確認
<!-- どのような動作確認を行ったのか？　結果はどうか？ -->
- ローカル環境にてテストを実施。

## その他
<!-- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載） -->
- 無し

## 関連Issue
<!-- このセクションでは、このPRが関連するIssueやタスクをリンクする。以下のように記述。 -->
- 関連Issue: 
