### PR TITLE
improve: ページ下の余白の削除,min-h-screen位置を修正

### DIFF
--- a/app/views/boards/index.html.erb
+++ b/app/views/boards/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:title, t('boards.index.title')) %>
-<div class="container mx-auto px-4">
+<div class="container mx-auto px-4 min-h-screen">
   <!-- ... -->
   <!-- 検索フォーム -->
   <%= render 'shared/search_board_form', search_form: @search_form %>
@@ -10,7 +10,7 @@
     </div>
   </div>
   <!-- 掲示板一覧 -->
-  <div class="flex flex-wrap min-h-screen justify-center gap-6">
+  <div class="flex flex-wrap justify-center gap-6">
     <% if @boards.present? %>
       <%= render @boards %>
     <% else %>

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -1,6 +1,6 @@
 <% content_for(:title, t('.title')) %>
-<div class="container mx-auto px-4">
-  <div class="flex min-h-full flex-col justify-center px-6 py-12 lg:px-8">
+<div class="container mx-auto px-4 min-h-screen">
+  <div class="flex flex-col justify-center px-6 py-12 lg:px-8">
     <h2 class="mt-10 text-center text-2xl font-bold leading-9 tracking-tight text-gray-900"><%= t('.title') %></h2>
   </div>
 

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -1,6 +1,6 @@
 <% content_for(:title, t('.title')) %>
-<div class="container mx-auto px-4">
-  <div class="flex min-h-screen flex-col justify-center px-6 py-12 lg:px-8">
+<div class="container mx-auto px-4 min-h-screen">
+  <div class="flex flex-col justify-center px-6 py-12 lg:px-8">
     <div class="sm:mx-auto sm:w-full sm:max-w-sm">
       <h2 class="mt-10 text-center text-2xl font-bold leading-9 tracking-tight text-gray-900"><%= t('.title') %></h2>
     </div>
@@ -13,9 +13,9 @@
       <div class="text-sm text-gray-500 mt-5 mb-2"><%= User.human_attribute_name(:avatar) %></div>
       <div><%= image_tag current_user.avatar_url, class: 'rounded-full', size: '80x80' %></div>
     </div>
-  </div>
-  <div class="flex justify-center">
+    <div class="flex justify-center">
     <button class="btn btn-success rounded-full text-zinc-100 mx-5 mb-10"><%= link_to t('defaults.edit'), edit_profile_path %></button>
     <button class="btn btn-error rounded-full text-zinc-100"><%= link_to t('defaults.delete'), profile_path, data: { turbo_method: "delete", turbo_confirm: t('defaults.delete_user_confirm') } %></button>
+  </div>
   </div>
 </div>


### PR DESCRIPTION
Closes #

## 概要
<!-- このセクションでは、このPRの目的と概要を簡潔に説明。 -->
-  ページ下の余白の削除のため、`min-h-screen`位置を修正。


## やったこと
<!-- このプルリクで何をしたのか？ -->
- 先ほど`min-h-screen`を入れた位置では、レイアウトが変になってしまったので、挿入場所を一番上にしました。

## やらないこと
<!-- このプルリクでやらないことは何か？（あれば。無いなら「無し」でOK）（やらない場合は、いつやるのかを明記する。） -->
- 無し

## できるようになること（ユーザ目線）
<!-- 何ができるようになるのか？（あれば。無いなら「無し」でOK） -->
- 無し

## できなくなること（ユーザ目線）
<!-- 何ができなくなるのか？（あれば。無いなら「無し」でOK） -->
- 無し

## 動作確認
<!-- どのような動作確認を行ったのか？　結果はどうか？ -->
- ローカル環境にて確認済み

## その他
<!-- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載） -->
- 無し

## 関連Issue
<!-- このセクションでは、このPRが関連するIssueやタスクをリンクする。以下のように記述。 -->
- 関連Issue: 
