### PR TITLE
add: 再ログイン時に、メールアドレス欄にユーザー名が入ってしまう問題の解決

### DIFF
--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -10,12 +10,12 @@
 
         <%= f.label :email, class: "form-label block text-sm font-medium leading-6 text-gray-900 mt-4" %>
         <div class="mt-1">
-          <%= f.email_field :email, class: "form-control block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6" %>
+          <%= f.email_field :email, class: "form-control block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6", autocomplete: "email" %>
         </div>
 
         <%= f.label :password, class: "form-label block text-sm font-medium leading-6 text-gray-900 mt-4" %>
         <div class="mt-1">
-          <%= f.password_field :password, class: "form-control block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6" %>
+          <%= f.password_field :password, class: "form-control block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6", autocomplete: "password" %>
         </div>
         <div class="text-center text-sm my-3">
         <%= f.submit t('.login'), class: "btn btn-secondary" %>


### PR DESCRIPTION
Closes #221

## 概要
<!-- このセクションでは、このPRの目的と概要を簡潔に説明。 -->
- 再ログイン時に、メールアドレス欄にユーザー名が入ってしまう問題の解決

## やったこと
<!-- このプルリクで何をしたのか？ -->
- `autocomplete: `の追加

## やらないこと
<!-- このプルリクでやらないことは何か？（あれば。無いなら「無し」でOK）（やらない場合は、いつやるのかを明記する。） -->
- 無し

## できるようになること（ユーザ目線）
<!-- 何ができるようになるのか？（あれば。無いなら「無し」でOK） -->
- 再ログイン時に、Googleの保存機能を使う際、メールアドレスとパスワードが正しく表示される。

## できなくなること（ユーザ目線）
<!-- 何ができなくなるのか？（あれば。無いなら「無し」でOK） -->
- 無し

## 動作確認
<!-- どのような動作確認を行ったのか？　結果はどうか？ -->
- ローカル環境にて確認済み

## その他
<!-- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載） -->
- 無し

## 関連Issue
<!-- このセクションでは、このPRが関連するIssueやタスクをリンクする。以下のように記述。 -->
- 関連Issue: 
