### PR TITLE
Fix/comment body line break

### DIFF
--- a/app/views/boards/show.html.erb
+++ b/app/views/boards/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:title, @board.title) %>
-<div class="container mx-auto w-full min-h-screen grid place-items-center bg-yellow-50">
+<div class="container mx-auto w-full min-h-screen grid place-items-center bg-yellow-50 pb-8">
   <div class="min-h-screen grid place-items-center bg-yellow-50 py-12">
     <div class="sm:mx-auto sm:w-full sm:max-w-sm">
       <h2 class="mt-5 mb-5 text-center text-2xl font-bold leading-9 tracking-tight text-gray-900"><%= t('.title') %></h2>
@@ -14,7 +14,7 @@
       </figure>
       <div class="card-body">
         <h2 class="card-title"><%= @board.title %>へ</h2>
-        <p class="text-gray-500"><%= @board.body %></p>
+        <p class="text-gray-500"><%= safe_join(@board.body.split("\n"),tag(:br)) %></p>
         <p class="text-gray-500"><%= render @board.tags %></p>
         <ul class="py-4 mt-2 text-gray-700 flex items-center justify-around">
           <% if current_user && current_user.own?(@board) %>

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -9,7 +9,7 @@
         <%= comment.user.name %>
         <% end %>
       </h3>
-      <p class="text-xs"><%= comment.body %></p>
+      <p class="text-xs"><%= safe_join(comment.body.split("\n"),tag(:br)) %></p>
     </div>
   </div>
 </div>

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -1,9 +1,9 @@
 <div class="mt-10 sm:mx-auto sm:w-full sm:max-w-80 lg:max-w-3xl">
   <%= form_with model: comment, url: board_comments_path(board) do |f| %>
     <div>
-      <%= f.label :body, class: "form-label block text-sm font-medium leading-6 text-gray-900" %>
+      <%= f.label :body, class: "form-label block text-sm font-bold leading-6 text-gray-900" %>
       <div class="mt-2">
-      <%= f.text_field :body, class: "form-control block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6 mb-2" %>
+      <%= f.text_area :body, class: "form-control block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6 mb-2 p-2" %>
     </div>
 
     <%= f.submit "コメントする", class: "btn btn-secondary text-gray-900" %>


### PR DESCRIPTION
Closes #299

## 概要
<!-- このセクションでは、このPRの目的と概要を簡潔に説明。 -->
- 投稿内容とコメントに改行機能の追加

## やったこと
<!-- このプルリクで何をしたのか？ -->
- `safe_join`の使用。

  ```
  # 投稿内容
  # app/views/boards/show.html.erb

   <%= safe_join(@board.body.split("\n"),tag(:br)) %>
  ```
  ```
  # コメント
  # app/views/comments/_comment.html.erb

   <%= safe_join(comment.body.split("\n"),tag(:br)) %>
  ```
- コメント入力フォームを`text_area`に修正。
  - 入力時にも改行や段落を追加できるようにするため。

## やらないこと
<!-- このプルリクでやらないことは何か？（あれば。無いなら「無し」でOK）（やらない場合は、いつやるのかを明記する。） -->
- 

## できるようになること（ユーザ目線）
<!-- 何ができるようになるのか？（あれば。無いなら「無し」でOK） -->
- 投稿内容、コメントでテキストの改行や段落ができるようになった。
  - 投稿内容の改行と段落
    [![Image from Gyazo](https://i.gyazo.com/2aa11e5cc153017cbaef5922ad492597.png)](https://gyazo.com/2aa11e5cc153017cbaef5922ad492597)
  - コメントの改行と段落、コメント入力フォームをtext_areaに。
    [![Image from Gyazo](https://i.gyazo.com/aa87bce0ee8d10d2afb8a68a7de9d8cc.png)](https://gyazo.com/aa87bce0ee8d10d2afb8a68a7de9d8cc)

## できなくなること（ユーザ目線）
<!-- 何ができなくなるのか？（あれば。無いなら「無し」でOK） -->
- 無し

## 動作確認
<!-- どのような動作確認を行ったのか？　結果はどうか？ -->
- ローカル環境にて確認済み。

## その他
<!-- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載） -->
- 参考資料
- [railsでtext_areaで入力したまま表示する（改行、段落）](https://qiita.com/kamotetu/items/1aa94994985c720668e4)

## 関連Issue
<!-- このセクションでは、このPRが関連するIssueやタスクをリンクする。以下のように記述。 -->
- 関連Issue: 
